### PR TITLE
Lock geoip2/geoip2 to 2.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "geoip2/geoip2": "~2.0",
+        "geoip2/geoip2": "2.10",
         "guzzlehttp/guzzle": "~6.1",
         "illuminate/config": "^6|^7|^8",
         "illuminate/http": "^6|^7|^8",


### PR DESCRIPTION
Lock geoip2/geoip2 to 2.10 due to breaking change in 2.11